### PR TITLE
fix: transpile react-syntax-highlighter for Turbopack prerender

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,11 @@ const nextConfig = {
   reactStrictMode: true,
   // Use Turbopack (Next.js 16 default) - handles minification and optimization automatically
   turbopack: {},
+  // react-syntax-highlighter ships CJS with dynamic requires into refractor/lowlight;
+  // Turbopack's external-module cache fails these at SSG time with
+  // "request for './lib/util/merge.js' is not in cache". Transpiling it bundles those
+  // paths through Turbopack's own resolver. See react-syntax-highlighter#600, vercel/next.js#86431.
+  transpilePackages: ['react-syntax-highlighter'],
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
Next.js 16 switched production builds to Turbopack by default. Turbopack's external-module cache fails on `react-syntax-highlighter`'s dynamic requires into `refractor`/`lowlight` at SSG time, breaking prerender of `/certs/[slug]`:

```
Error: Failed to load external module react-syntax-highlighter:
  Error: request for './lib/util/merge.js' is not in cache
  at Context.externalRequire [as x] (.next/server/chunks/ssr/[turbopack]_runtime.js:514:15)
...
Export encountered an error on /certs/[slug]: /certs/aws-saa-cert-legacy, exiting the build.
```

This surfaced on Cloudflare Pages (`@cloudflare/next-on-pages@1` → `vercel build` → `next build`) and is the same bug class latent on Vercel - non-deterministic module cache ordering just happens to favor Vercel's runtime today.

## Changes
**Modified:** `next.config.mjs` - add `transpilePackages: ['react-syntax-highlighter']` with an inline comment explaining why.

## Rationale
`transpilePackages` routes the package through Turbopack's own resolver so the dynamic `require()` paths into `lib/util/merge.js` etc. are bundled eagerly instead of deferred to an external-module cache that isn't populated at prerender time. This is the documented workaround in react-syntax-highlighter#600 and tracks with vercel/next.js#86431.

Alternative considered: `next build --webpack` to opt out of Turbopack entirely. Rejected because it gives up Turbopack's build perf for every other route unnecessarily; the surgical fix is preferable.

## Testing
Local build on this branch against current `main` deps:

```
$ npm run build
...
├ ● /certs/[slug] (1788 ms)                           10m      1y
│ ├ /certs/aws-saa-cert-legacy (566 ms)
│ ├ /certs/aws-saa-cert (566 ms)
│ ├ /certs/certified-scrummaster (565 ms)
...
```

✅ `/certs/aws-saa-cert-legacy` (the page that fails on CF) now prerenders cleanly.
✅ All other `/certs/[slug]`, `/blog/[slug]`, `/projects/[slug]` routes prerender cleanly.
✅ No new warnings.

## Related
- react-syntax-highlighter/react-syntax-highlighter#600
- vercel/next.js#86431
- Next.js 16 release notes (Turbopack default for `next build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)