### PR TITLE
refactor: switch to Next.js static export for Cloudflare Pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  // Use Turbopack (Next.js 16 default) - handles minification and optimization automatically
+  // Fully static site - all content sourced from markdown at build time.
+  // Emits HTML+assets to out/, deploys directly to Cloudflare Pages with no runtime.
+  output: 'export',
   turbopack: {},
   // react-syntax-highlighter ships CJS with dynamic requires into refractor/lowlight;
   // Turbopack's external-module cache fails these at SSG time with
@@ -9,6 +11,9 @@ const nextConfig = {
   // paths through Turbopack's own resolver. See react-syntax-highlighter#600, vercel/next.js#86431.
   transpilePackages: ['react-syntax-highlighter'],
   images: {
+    // Next's image optimizer requires a server; with static export, images are served as-is.
+    // Originals already live on cdn.levine.io, so no optimization is lost.
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -49,7 +49,6 @@ export const getStaticProps = async ({ params }) => {
     props: {
       blog: { ...blogData, id, content },
     },
-    revalidate: 600,
   };
 };
 

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -41,6 +41,5 @@ export const getStaticProps = async () => {
     props: {
       blog: minimalBlogData,
     },
-    revalidate: 600, // Add revalidation for better performance
   };
 };

--- a/pages/certs/[slug].js
+++ b/pages/certs/[slug].js
@@ -48,7 +48,6 @@ export const getStaticProps = async ({ params }) => {
     props: {
       cert: certData,
     },
-    revalidate: 600,
   };
 };
 

--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -50,7 +50,6 @@ export const getStaticProps = async ({ params }) => {
         id: projectData.id || 'default-id', // Ensure the project has an id
       },
     },
-    revalidate: 600,
   };
 };
 


### PR DESCRIPTION
## Summary

Every route on this site is fully static - all content comes from markdown files in `/data/` processed at build time, and there are no API routes, no SSR, no middleware, no server actions. The Next.js runtime was only along for the ride via the now-deprecated `@cloudflare/next-on-pages`. Switching to `output: 'export'` ships the site as plain HTML and bypasses that entire migration story (OpenNext targets Workers, not Pages, and is designed for SSR apps - overkill here).

## Changes

**Modified:**
- `next.config.mjs` — add `output: 'export'` and `images: { unoptimized: true }`. The Next image optimizer needs a server; originals already live on `cdn.levine.io`, so no optimization is lost.
- `pages/blog/index.js`, `pages/blog/[slug].js`, `pages/certs/[slug].js`, `pages/projects/[slug].js` — remove `revalidate: 600`. ISR only helps when content changes outside of builds; every content change here is a markdown commit that triggers a fresh deploy, so revalidation was a no-op.

## Rationale

### Why static export over OpenNext/Workers?
- `@cloudflare/next-on-pages@1` is deprecated (its README explicitly says so).
- OpenNext's Cloudflare adapter targets Workers, not Pages, and is purpose-built for SSR. This site has no SSR surface.
- Static export keeps the current Pages project, custom domain, and DNS untouched.
- Zero runtime cost; every route served from CF's edge as a flat HTML file.

### Animations / interactivity still work
`framer-motion`, `aos`, `react-intersection-observer` all run client-side after hydration. Static export doesn't change that - the JS bundle still ships and executes in the browser identically.

## Testing

Local `npm run build` on this branch:

```
✓ Generating static pages using 9 workers (55/55) in 984.0ms
   Finalizing page optimization ...
   Exporting using 9 workers (0/9) ...

Route (pages)
┌ ● /
├ ○ /404
├ ○ /about
├ ● /blog
├ ● /blog/[slug]   (30 paths)
├ ● /certs
├ ● /certs/[slug]  (10 paths, incl. aws-saa-cert-legacy)
├ ● /now
├ ● /projects
├ ● /projects/[slug] (6 paths)
└ ● /rss
```

✅ All 55 pages prerender; `out/` contains full HTML tree (`out/blog/*.html`, `out/certs/*.html`, `out/projects/*.html`) plus `out/rss.xml` (170KB) and `out/_next/` assets.
✅ `/certs/aws-saa-cert-legacy` - the page that was failing on CF Pages - exports cleanly.

## Deployment - Cloudflare Pages dashboard changes required

Before merging, the `daves-portfolio` Pages project settings must be updated to match:

| Setting | Old | New |
|---|---|---|
| Build command | `npx @cloudflare/next-on-pages@1` | `npm run build` |
| Build output directory | `.vercel/output/static` | `out` |
| Compatibility flags | `nodejs_compat` | *(remove)* |

`NODE_VERSION=22.16.0` can stay as-is.

## Related
- Precursor: #365 (Turbopack + react-syntax-highlighter fix) - now redundant but harmless; the `transpilePackages` line can stay or be removed in a follow-up since Turbopack still runs at build time for static export.
- `@cloudflare/next-on-pages` deprecation: https://github.com/cloudflare/next-on-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)