### PR TITLE
docs(content): refresh /now and /about pages

### DIFF
--- a/components/about/about.js
+++ b/components/about/about.js
@@ -51,11 +51,11 @@ const About = () => {
             <h1>Designing effective solutions, organizing knowledge, and conveying complexity through visual design.</h1>
             <br />
             <p className={classes.h3}>
-              I&apos;m an information systems pro with a knack for building relationships and technical expertise to make great things happen. I&apos;m experienced in leading diverse teams, and together, we&apos;ve tackled the finer details of business processes, enhanced the technical aspects, ensured top-notch quality, and made web-based solutions shine.
+              I&apos;m a Solutions Engineer at Weill Cornell Medicine, where I help keep a portfolio of research administration systems running smoothly. Most of my work lives somewhere between infrastructure, security, and documentation. I like figuring out how things fit together, writing it down clearly, and making sure the next person doesn&apos;t have to start from scratch.
             </p>
             <br />
             <p className={classes.h3}>
-              Most recently, my role involves shaping application architecture, fine-tuning development processes, and actively participating in solution design discussions to meet specific business needs.
+              Lately, a lot of my time goes to drawing architecture diagrams, mapping how our services depend on one another, and helping with a big migration to a new system. Outside of work, I build and self-host things I find useful, like a micro-journaling app, my personal knowledge base, and a homelab that&apos;s a constant yet rewarding project.
             </p>
           </div>
 

--- a/data/now/now.md
+++ b/data/now/now.md
@@ -1,5 +1,5 @@
 ---
-date: "2025-01-15T16:37:00Z"
+date: "2026-04-21T16:37:00Z"
 ---
 #
 
@@ -9,9 +9,17 @@ This is my [Now Page]: a brief update on what's currently happening in my life, 
 
 ## Personal
 
-> **Update:** I started reading [Endurance: Shackleton's Incredible Voyage] by Alfred Lansing. While it's certainly a compelling survival story, it's also a masterclass in crisis leadership through unimaginable adversity. I'm enjoying every second of it.
+> **Update:** I've finished three books over the past year:
+>
+> * [The Hitchhiker's Guide to the Galaxy] by Douglas Adams
+> * [Train Dreams] by Denis Johnson
+> * [The Sunset Limited] by Cormac McCarthy
+>
+> A wildly different trio, but each one stuck with me for its own reasons.
 
-I've officially been in my house for 8 years now. Between that, my wife, and two kids, I have no problem staying busy. It’s hard to believe I’ve been working remotely for nearly 4.5 years, which allows me to maintain a healthy work-life balance. Watching my kids grow up so quickly has been both wonderful and surreal.
+I've officially been in my house for 9 years now. Between that, my wife, and two kids, I have no problem staying busy. It’s hard to believe I’ve been working remotely for nearly 5.5 years, which allows me to maintain a healthy work-life balance. Watching my kids grow up so quickly has been both wonderful and surreal.
+
+A lot of my time outside of work goes to them, which is exactly how I want it. We spend hours building with Legos, drawing together, and whatever else they’re into that week. I also love teaching them about things they're curious about, whether it's how something works, where rain comes from, or why leaves change color in the fall. They ask great questions, and I'm doing my best to keep up.
 
 I really enjoy reading, although I don't get to do it as often as I'd like. A non-exhaustive list of some of the books I've enjoyed over the years can be found [here].
 
@@ -19,7 +27,7 @@ Also, I've been getting back into exercising after a prolonged hiatus. It's been
 
 Whatever’s left of my spare time is spent:
 
-* Updating my [portfolio] to showcase my latest projects and achievements.
+* Building [Journalistic], a micro-journaling PWA I wrote from scratch to capture daily thoughts and reflections, inspired by the [original Journalistic app] (no shared code).
 * Building out my personal [knowledge base] with new content and resources.
 * Managing and updating my [homelab], which is a constant yet rewarding project.
 
@@ -29,15 +37,18 @@ I’ve been with [Weill Cornell Medicine] since October 2015, now working as a S
 
 Lately, I’ve been focusing on:
 
-* Refining application architecture to stay ahead of the curve.
-* Helping our team work better together by simplifying processes and ensuring everyone’s on the same page.
-* Working closely with others to design solutions that fit the organization's needs and make a difference in how we operate.
+* Contributing to a large SAP-to-Workday migration initiative by documenting existing system integrations and data feeds to support integration planning.
+* Maintaining a mature TLS certificate renewal process across our research systems, now in its fourth year as a largely self-sustaining operational routine.
+* Designing multi-cloud architecture diagrams and a comprehensive service dependency matrix that maps upstream and downstream relationships across all RAC services, giving the team a shared resource for incident impact assessments and strategic planning.
 
   [now page]: https://nownownow.com/about
-  [Endurance: Shackleton's Incredible Voyage]: https://en.wikipedia.org/wiki/Endurance:_Shackleton%27s_Incredible_Voyage
-  [portfolio]: https://dave.levine.io
+  [The Hitchhiker's Guide to the Galaxy]: https://en.wikipedia.org/wiki/The_Hitchhiker%27s_Guide_to_the_Galaxy_(novel)
+  [Train Dreams]: https://en.wikipedia.org/wiki/Train_Dreams
+  [The Sunset Limited]: https://en.wikipedia.org/wiki/The_Sunset_Limited
   [knowledge base]: https://kb.levine.io
-  [homelab]: https://cdn.levine.io/uploads/images/gallery/2023-11/network-diagram-1.png
+  [original Journalistic app]: https://journalisticapp.com
+  [homelab]: https://cdn.levine.io/uploads/images/gallery/2025-10/systems-architecture-diagram-dark-2025-10-10.webp
+  [Journalistic]: https://journal-dev.levine.io
   [Weill Cornell Medicine]: https://weill.cornell.edu/
   [Derek Sivers]: https://sive.rs/now
   [here]: https://kb.levine.io/about/lists/books/

--- a/data/projects/journalistic.md
+++ b/data/projects/journalistic.md
@@ -33,7 +33,7 @@ Everything lives in a single SQLite file you control. No cloud accounts, no subs
 * Full [PWA] support with a three-layer cache (memory, localStorage, IndexedDB) for instant offline navigation.
 * Optional [Dreams, Wisdom, Ideas, and Notes] modules that stay hidden until enabled.
 
-  [Journalistic]: https://journalisticapp.com
+  [Journalistic]: https://journal-dev.levine.io
   [SQLite]: https://www.sqlite.org/
   [Litestream]: https://litestream.io/
   [#tags and @people]: https://journal-dev.levine.io


### PR DESCRIPTION
## Summary
- Refresh the /now page with current personal, reading, and professional context, plus a Journalistic bullet in the spare-time list (with attribution to the original app).
- Rewrite the /about page body paragraphs in a plainer voice, grounded in the current Solutions Engineer role at Weill Cornell Medicine and mentioning side work.
- Fix the Journalistic live link on the /projects page to point at the correct URL.

## Changes
**Modified:**
- \`data/now/now.md\`
  - Added Journalistic at the top of the spare-time list, with attribution to the original app and a link to the new instance (\`journal-dev.levine.io\`).
  - Removed the portfolio bullet from the spare-time list.
  - Updated the homelab link to the current systems architecture diagram.
  - Bumped house tenure to 9 years and remote work to 5.5 years.
  - Replaced the stale Endurance blockquote with a bulleted list of three books finished this past year (Hitchhiker's Guide, Train Dreams, The Sunset Limited).
  - Refreshed the professional bullets with current initiatives (SAP-to-Workday migration, TLS renewal process, service dependency matrix / architecture diagrams).
  - Added a paragraph about time with the kids (Legos, drawing, curiosity questions).
  - Bumped the front-matter \`date\` to the current date.
- \`components/about/about.js\`
  - Rewrote the two body paragraphs in a plainer, less jargon-heavy voice, grounded in the Weill Cornell Solutions Engineer role and side work (Journalistic, knowledge base, homelab).
  - Kept the headline unchanged.
- \`data/projects/journalistic.md\`
  - Updated the \`[Journalistic]\` reference link from \`journalisticapp.com\` to \`journal-dev.levine.io\`.

## Rationale
The /now page had drifted: the reading blockquote, tenure pins, and professional bullets were all from early 2025 and no longer reflected current state. The /about copy was generic enough to apply to anyone in any role, which didn't do the page any favors. This pass brings both pages up to date and makes them sound more like me.

## Testing
- [x] Reviewed the rendered Markdown changes for voice and formatting consistency
- [x] Verified all reference link labels resolve to defined URLs
- [ ] Visual QA in the dev server after merge

## Related
Follow-up to #371 (adding Journalistic to the projects list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)