### PR TITLE
style(blog): cohesive theme + tokenized code styling

### DIFF
--- a/components/blog/blog.module.scss
+++ b/components/blog/blog.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/ui.scss'; 
+@use '../../styles/ui' as *;
 
 .blogGallery {
   padding: 50px 15px;

--- a/components/blog/blogContent.js
+++ b/components/blog/blogContent.js
@@ -65,178 +65,89 @@ import 'yet-another-react-lightbox/plugins/thumbnails.css';
 
 import classes from './blogContent.module.scss';
 
-// Custom syntax highlighting theme for dark mode
-const syntaxTheme = {
-  'code[class*="language-"]': {
-    color: '#cdd9e5',
-    background: '#1B1C32',
-    fontFamily: 'monospace',
-    fontSize: '14px',
-    textAlign: 'left',
-    whiteSpace: 'pre',
-    wordSpacing: 'normal',
-    wordBreak: 'normal',
-    wordWrap: 'normal',
-    lineHeight: '1.5',
-    tabSize: 4,
-    hyphens: 'none',
-    padding: 0,
-  },
-  'pre[class*="language-"]': {
-    color: '#cdd9e5',
-    background: '#1B1C32',
-    fontFamily: 'monospace',
-    fontSize: '14px',
-    textAlign: 'left',
-    whiteSpace: 'pre',
-    wordSpacing: 'normal',
-    wordBreak: 'normal',
-    wordWrap: 'normal',
-    lineHeight: '1.5',
-    tabSize: 4,
-    hyphens: 'none',
-    margin: 0,
-    padding: 0,
-    overflow: 'auto',
-  },
-  // Comments - consistent across all languages
-  comment: { color: '#6a8a99' },
-  prolog: { color: '#6a8a99' },
-  doctype: { color: '#6a8a99' },
-  cdata: { color: '#6a8a99' },
+// Single theme driven by CSS variables — light/dark switch via :root vs [data-theme='dark']
+const KEYWORD = 'var(--code-block-keyword)';
+const NUMBER = 'var(--code-block-number)';
+const STRING = 'var(--code-block-string)';
+const TEXT = 'var(--code-block-text)';
+const COMMENT = 'var(--code-block-comment)';
 
-  // Keywords, properties, tags, selectors - consistently in lime green
-  keyword: { color: '#a3e600' },
-  property: { color: '#a3e600' },
-  tag: { color: '#a3e600' },
-  'class-name': { color: '#a3e600' },
-  'attr-name': { color: '#a3e600' },
-  selector: { color: '#a3e600' },
-  'selector-tag': { color: '#a3e600' },
-  'selector-class': { color: '#a3e600' },
-  'selector-attr': { color: '#a3e600' },
-  'selector-pseudo': { color: '#a3e600' },
-
-  // Functions and methods - lime green
-  function: { color: '#a3e600' },
-  'function-variable': { color: '#a3e600' },
-  method: { color: '#a3e600' },
-
-  // Numbers, booleans, regex - accent color
-  number: { color: '#ff5d5d' },
-  boolean: { color: '#ff5d5d' },
-  regex: { color: '#ff5d5d' },
-  'attr-value': { color: '#ff5d5d' },
-
-  // Strings, punctuation, operators - default text
-  string: { color: '#cdd9e5' },
-  char: { color: '#cdd9e5' },
-  builtin: { color: '#cdd9e5' },
-  entity: { color: '#cdd9e5' },
-  url: { color: '#cdd9e5' },
-  symbol: { color: '#cdd9e5' },
-  punctuation: { color: '#cdd9e5' },
-  operator: { color: '#cdd9e5' },
-
-  // Language specific tokens
-  // Markup (HTML/XML)
-  namespace: { color: '#cdd9e5' },
-
-  // CSS
-  important: { color: '#a3e600' },
-  rule: { color: '#a3e600' },
-  atrule: { color: '#a3e600' },
-
-  // JavaScript/TypeScript
-  'template-string': { color: '#cdd9e5' },
-  literal: { color: '#ff5d5d' },
-  variable: { color: '#a3e600' },
-  'attr-equals': { color: '#cdd9e5' },
-
-  // PHP
-  delimiter: { color: '#cdd9e5' },
-
-  // Shell
-  'shell-symbol': { color: '#a3e600' },
-  command: { color: '#a3e600' },
-  parameter: { color: '#a3e600' },
-  'command-name': { color: '#a3e600' },
-
-  // YAML
-  'yaml-punctuation': { color: '#cdd9e5' },
-
-  // INI-specific tokens
-  section: { color: '#a3e600' },
-  constant: { color: '#ff5d5d' },
-
-  // Special formats
-  bold: { fontWeight: 'bold' },
-  italic: { fontStyle: 'italic' },
+const baseBlock = {
+  color: TEXT,
+  background: 'var(--code-block-bg)',
+  fontFamily: 'var(--font-fira-code), Menlo, monospace',
+  fontSize: '14px',
+  textAlign: 'left',
+  whiteSpace: 'pre',
+  wordSpacing: 'normal',
+  wordBreak: 'normal',
+  wordWrap: 'normal',
+  lineHeight: '1.5',
+  tabSize: 4,
+  hyphens: 'none',
 };
 
-// Light theme version with consistent styling
-const lightSyntaxTheme = {
-  ...syntaxTheme,
-  'code[class*="language-"]': {
-    ...syntaxTheme['code[class*="language-"]'],
-    color: '#2c3e50',
-    background: '#f5f5f5',
-  },
-  'pre[class*="language-"]': {
-    ...syntaxTheme['pre[class*="language-"]'],
-    color: '#2c3e50',
-    background: '#f5f5f5',
-  },
-  // Matching the exact colors from the screenshot
-  comment: { color: '#a0a0a0' },
-  prolog: { color: '#a0a0a0' },
-  doctype: { color: '#a0a0a0' },
-  cdata: { color: '#a0a0a0' },
+const syntaxTheme = {
+  'code[class*="language-"]': { ...baseBlock, padding: 0 },
+  'pre[class*="language-"]': { ...baseBlock, margin: 0, padding: 0, overflow: 'auto' },
 
-  // Keywords in magenta
-  keyword: { color: '#FF0084' },
-  property: { color: '#FF0084' },
-  tag: { color: '#FF0084' },
-  'class-name': { color: '#FF0084' },
-  'attr-name': { color: '#FF0084' },
-  selector: { color: '#FF0084' },
-  'selector-tag': { color: '#FF0084' },
-  'selector-class': { color: '#FF0084' },
-  'selector-attr': { color: '#FF0084' },
-  'selector-pseudo': { color: '#FF0084' },
-  function: { color: '#FF0084' },
-  'function-variable': { color: '#FF0084' },
-  method: { color: '#FF0084' },
+  // Comments
+  comment: { color: COMMENT, fontStyle: 'italic' },
+  prolog: { color: COMMENT },
+  doctype: { color: COMMENT },
+  cdata: { color: COMMENT },
 
-  // Numbers and values in slightly different color
-  number: { color: '#EF5350' },
-  boolean: { color: '#EF5350' },
-  regex: { color: '#EF5350' },
-  'attr-value': { color: '#EF5350' },
+  // Keywords / identifiers / structure
+  keyword: { color: KEYWORD },
+  property: { color: KEYWORD },
+  tag: { color: KEYWORD },
+  'class-name': { color: KEYWORD },
+  'attr-name': { color: KEYWORD },
+  selector: { color: KEYWORD },
+  'selector-tag': { color: KEYWORD },
+  'selector-class': { color: KEYWORD },
+  'selector-attr': { color: KEYWORD },
+  'selector-pseudo': { color: KEYWORD },
+  function: { color: KEYWORD },
+  'function-variable': { color: KEYWORD },
+  method: { color: KEYWORD },
+  variable: { color: KEYWORD },
+  important: { color: KEYWORD },
+  rule: { color: KEYWORD },
+  atrule: { color: KEYWORD },
+  'shell-symbol': { color: KEYWORD },
+  command: { color: KEYWORD },
+  parameter: { color: KEYWORD },
+  'command-name': { color: KEYWORD },
+  section: { color: KEYWORD },
 
-  // Regular text/strings in dark gray
-  string: { color: '#2c3e50' },
-  char: { color: '#2c3e50' },
-  builtin: { color: '#2c3e50' },
-  entity: { color: '#2c3e50' },
-  url: { color: '#2c3e50' },
-  symbol: { color: '#2c3e50' },
-  punctuation: { color: '#2c3e50' },
-  operator: { color: '#2c3e50' },
+  // Numbers / booleans / literals
+  number: { color: NUMBER },
+  boolean: { color: NUMBER },
+  regex: { color: NUMBER },
+  'attr-value': { color: NUMBER },
+  literal: { color: NUMBER },
+  constant: { color: NUMBER },
 
-  // Other language-specific tokens for light theme
-  variable: { color: '#FF0084' },
-  important: { color: '#FF0084' },
-  rule: { color: '#FF0084' },
-  atrule: { color: '#FF0084' },
-  'shell-symbol': { color: '#FF0084' },
-  command: { color: '#FF0084' },
-  parameter: { color: '#FF0084' },
-  'command-name': { color: '#FF0084' },
+  // Strings (now distinct from default text)
+  string: { color: STRING },
+  char: { color: STRING },
+  'template-string': { color: STRING },
+  url: { color: STRING },
 
-  // INI-specific tokens for light theme
-  section: { color: '#FF0084' },
-  constant: { color: '#EF5350' },
+  // Default-text tokens
+  builtin: { color: TEXT },
+  entity: { color: TEXT },
+  symbol: { color: TEXT },
+  punctuation: { color: TEXT },
+  operator: { color: TEXT },
+  namespace: { color: TEXT },
+  'attr-equals': { color: TEXT },
+  delimiter: { color: TEXT },
+  'yaml-punctuation': { color: TEXT },
+
+  bold: { fontWeight: 'bold' },
+  italic: { fontStyle: 'italic' },
 };
 
 // Component for copy button
@@ -259,15 +170,16 @@ const CopyButton = ({ text }) => {
     <button
       onClick={copyToClipboard}
       className={classes.copyButton}
-      aria-label="Copy code to clipboard"
-      title="Copy code to clipboard"
+      aria-label={copied ? 'Code copied to clipboard' : 'Copy code to clipboard'}
+      aria-live="polite"
+      title={copied ? 'Copied!' : 'Copy code to clipboard'}
     >
       {copied ? (
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
           <polyline points="20 6 9 17 4 12"></polyline>
         </svg>
       ) : (
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
           <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
           <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
         </svg>
@@ -396,13 +308,13 @@ const BlogContent = ({
               <CopyButton text={codeString} />
             </div>
             <SyntaxHighlighter
-              style={currentTheme === 'dark' ? syntaxTheme : lightSyntaxTheme}
+              style={syntaxTheme}
               language={mappedLang}
               PreTag="div"
               showLineNumbers={true}
-              lineNumberStyle={{ 
+              lineNumberStyle={{
                 minWidth: '2em',
-                color: currentTheme === 'dark' ? '#6a8a99' : '#a0a0a0',
+                color: 'var(--code-block-line-number)',
                 textAlign: 'right',
                 paddingRight: '1em',
                 userSelect: 'none',
@@ -410,8 +322,8 @@ const BlogContent = ({
               }}
               customStyle={{
                 margin: 0,
-                padding: '0.75em 0',
-                background: currentTheme === 'dark' ? '#1B1C32' : '#f5f5f5',
+                padding: '1em 1.25em',
+                background: 'var(--code-block-bg)',
                 borderRadius: 0,
               }}
               {...props}

--- a/components/blog/blogContent.module.scss
+++ b/components/blog/blogContent.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/ui.scss';
+@use '../../styles/ui' as *;
 
 .blogDetail {
   // Common text styles
@@ -99,12 +99,8 @@
   }
 
   strong {
-    background: #cecece;
-    padding: 0 4px;
-    border-radius: 8px;
-    color: black;
-    font-weight: 400;
-    font-size: 0.9rem; // Increased font size for better spacing
+    color: var(--navbar-primary);
+    font-weight: 700;
   }
 
   .card,
@@ -276,10 +272,6 @@
   code {
     white-space: pre-wrap;
     word-wrap: break-word;
-    color: var(--accent);
-    border-radius: 5px;
-    padding: 2px 4px;
-    font-weight: 500;
     overflow-wrap: break-word;
   }
 
@@ -311,40 +303,43 @@
 
 .codeBlockContainer {
   position: relative;
-  margin: auto 0;
+  margin: 1em 0;
   overflow: hidden;
-  border-radius: 0;
+  border-radius: 8px;
+  border: 1px solid var(--code-block-border);
+  background-color: var(--code-block-bg);
 
-  &:hover {
-    .codeHeader {
-      opacity: 1;
-    }
+  &:hover .codeHeader,
+  &:focus-within .codeHeader {
+    opacity: 1;
   }
 }
 
 .codeHeader {
   position: absolute;
-  top: 8px;
-  right: 8px;
-  z-index: 10;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 1;
   opacity: 0;
-  transition: opacity 0.2s ease-in-out;
+  transition: opacity var(--transition-speed) ease;
 }
 
 .copyButton {
-  background-color: rgba(0, 0, 0, 0.3);
-  border: none;
+  background-color: var(--code-block-header-bg);
+  border: 1px solid var(--code-block-border);
   border-radius: 4px;
-  padding: 0.25rem 0.5rem;
+  padding: 0.25rem 0.4rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s ease;
-  color: #cdd9e5;
+  transition: background-color var(--transition-speed) ease,
+              color var(--transition-speed) ease,
+              transform var(--transition-speed) ease;
+  color: var(--code-block-meta);
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.5);
+    color: var(--code-block-text);
   }
 
   &:active {
@@ -352,18 +347,21 @@
   }
 }
 
-.inlineCode {
-  background-color: var(--border-light);
-  color: var(--accent);
-  font-family: monospace;
-  padding: 0.2em 0.4em;
-  border-radius: 4px;
-  font-size: 0.9em;
-}
-
-/* Mobile adjustments */
-@media only screen and (max-width: 767px) {
+@media (hover: none) {
   .codeHeader {
-    opacity: 1; /* Always show copy button on mobile */
+    opacity: 1;
   }
 }
+
+.inlineCode {
+  background-color: var(--inline-code-bg);
+  color: var(--inline-code-color);
+  font-family: var(--font-fira-code), Menlo, monospace;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.875em;
+  font-weight: 500;
+  border: 1px solid var(--inline-code-border);
+  overflow-wrap: anywhere;
+}
+

--- a/components/blog/blogItem.module.scss
+++ b/components/blog/blogItem.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/ui.scss'; 
+@use '../../styles/ui' as *;
 
 .card {
   border-radius: 8px;

--- a/components/certs/allCerts.module.scss
+++ b/components/certs/allCerts.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/ui.scss'; 
+@use '../../styles/ui' as *;
 
 .certs {
   padding: 50px 15px;

--- a/components/certs/certItem.module.scss
+++ b/components/certs/certItem.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/ui.scss'; 
+@use '../../styles/ui' as *;
 
 .card {
   border-radius: 8px;

--- a/components/now/now.module.scss
+++ b/components/now/now.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/ui.scss';
+@use '../../styles/ui' as *;
 
 .now {
   padding: 60px 15px;

--- a/components/projects/allProjects.module.scss
+++ b/components/projects/allProjects.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/ui.scss'; 
+@use '../../styles/ui' as *;
 
 .projectsGallery {
   padding: 50px 15px;

--- a/components/projects/projectContent.module.scss
+++ b/components/projects/projectContent.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/ui.scss';
+@use '../../styles/ui' as *;
 
 .projectDetail {
   // Mixin for common text styles to ensure reusability

--- a/components/projects/projectItem.module.scss
+++ b/components/projects/projectItem.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/ui.scss'; 
+@use '../../styles/ui' as *;
 
 .card {
   border-radius: 8px;

--- a/data/posts/infrastructure-as-code.md
+++ b/data/posts/infrastructure-as-code.md
@@ -35,7 +35,7 @@ I looked for a different course and found the [Getting Started with Ansible](htt
 
 Finishing a course and doing the work are two very different things. The first weeks of `homelab-iac` were rough. I'd write a role, run it, watch it blow up, fix it, watch it blow up somewhere else, and repeat. The papercuts piled up fast:
 
-- Tasks that worked the first time and changed something the second — the opposite of idempotency.
+- Tasks that worked the first time and changed something the second, the opposite of idempotency.
 - Tripping over `become` and file ownership.
 - Getting the order of operations wrong and breaking a host mid-run.
 
@@ -71,7 +71,7 @@ Importing existing infrastructure was, again, less about the tool and more about
 The thing I'm most happy with on the OpenTofu side is how state is handled. State lives in Cloudflare R2, and credentials are pulled out of Bitwarden Secrets Manager at runtime via a small wrapper script:
 
 ```bash
-# tofu-bw.sh — exports R2 creds for the backend, then exec's tofu
+# tofu-bw.sh: exports R2 creds for the backend, then exec's tofu
 export AWS_ACCESS_KEY_ID=$(bws secret get "$R2_KEY_ID_UUID"     --output json | jq -r '.value')
 export AWS_SECRET_ACCESS_KEY=$(bws secret get "$R2_SECRET_UUID" --output json | jq -r '.value')
 
@@ -111,7 +111,7 @@ on:
 
 Getting it reliable took a while. A non-exhaustive list of what had to be sorted out before I could walk away from the system:
 
-- Playbooks intermittently failing because Bitwarden Secrets Manager was being hit too many times in parallel — fixed by serializing host execution so BWS lookups didn't pile up.
+- Playbooks intermittently failing because Bitwarden Secrets Manager was being hit too many times in parallel. Fixed by serializing host execution so BWS lookups didn't pile up.
 - Compose files on hosts slowly drifting out of sync with the repo when a deploy was interrupted partway through, with reconciliation not always noticing.
 - A multi-PR effort to detect drift, self-heal it, pre-resolve sudo passwords once per run instead of per-task, and fix a callback plugin that was reporting "success" for tasks that had actually skipped.
 
@@ -148,10 +148,10 @@ A homelab without monitoring is just a collection of things you'll find out are 
 
 I consolidated around four pieces:
 
-- **[Homepage](https://gethomepage.dev)** — my dashboard, and the first thing I see when I open a browser tab.
-- **[Gatus](https://github.com/TwiN/gatus)** — replaced Uptime Kuma for health checking. Configured in YAML, so the entire thing lives in the repo alongside everything else.
-- **[Beszel](https://beszel.dev/)** — host-level metrics.
-- **[Ntfy](https://ntfy.sh)** — the pipe through which everything reaches my phone.
+- **[Homepage](https://gethomepage.dev)**: my dashboard, and the first thing I see when I open a browser tab.
+- **[Gatus](https://github.com/TwiN/gatus)**: replaced Uptime Kuma for health checking. Configured in YAML, so the entire thing lives in the repo alongside everything else.
+- **[Beszel](https://beszel.dev/)**: host-level metrics.
+- **[Ntfy](https://ntfy.sh)**: the pipe through which everything reaches my phone.
 
 [Healthchecks.io](https://healthchecks.io/) sits alongside all of that as my dead-man's-switch monitor for systemd timers and cron jobs. If a backup doesn't check in on time, I know about it. If a `package-updates` run skips a host, I know about it. The mental load of "I hope that thing ran" is gone, and that alone has been worth it.
 
@@ -170,9 +170,9 @@ Once the foundation was in place, the homelab stopped feeling like a project and
 - **An Astro Starlight docs site.** The homelab documentation had been spread across READMEs and a Bookstack instance, neither of which was great. I set up a [Starlight](https://starlight.astro.build/) site that lives next to the code at [wired.io](https://wired.io). I tried to migrate the site from Cloudflare Pages to Workers about a week after standing it up, hit a problem I didn't want to debug at 11pm on a Friday, and reverted it back to Pages. That revert is sitting in the git log staring at me, and I'll come back to it eventually.
 - **Dotfiles via chezmoi.** I added an Ansible role that bootstraps [chezmoi](https://www.chezmoi.io/) on any new machine and pulls down my dotfiles. Going from "format a laptop and spend an evening getting it back to the way I like it" to a single command is genuinely satisfying.
 - **A multi-week Postgres detour for Journalistic.** I run a small open-source project called [Journalistic](https://github.com/davelevine/journalistic), and at one point I decided to move its storage from SQLite plus [Litestream](https://litestream.io/) over to PostgreSQL with point-in-time recovery. The path went something like this:
-    1. restic for `pg_dump` snapshots and [WAL-G](https://github.com/wal-g/wal-g) for WAL archiving to R2 — WAL-G didn't fit.
-    2. Swapped to [pgBackRest](https://pgbackrest.org/) — wasn't the right shape either.
-    3. Tried barman-cloud via the [CNPG](https://cloudnative-pg.io/) image with gzip-compressed WAL and base backups — got it working, but had to admit the operational surface area was way more than the project needed.
+    1. restic for `pg_dump` snapshots and [WAL-G](https://github.com/wal-g/wal-g) for WAL archiving to R2. WAL-G didn't fit.
+    2. Swapped to [pgBackRest](https://pgbackrest.org/), which wasn't the right shape either.
+    3. Tried barman-cloud via the [CNPG](https://cloudnative-pg.io/) image with gzip-compressed WAL and base backups. Got it working, but had to admit the operational surface area was way more than the project needed.
     4. Ripped it out and reverted to SQLite plus Litestream.
 
     The detour cost weeks. I learned a lot about WAL archiving, but mostly it was a lesson in knowing when to stop.
@@ -184,7 +184,7 @@ Once the foundation was in place, the homelab stopped feeling like a project and
     4. Swap the Homepage tile.
     5. Drop the SMB mount.
 
-The pilot itself was not smooth — CORS had to be set explicitly for the WebGUI, the healthcheck had to be TCP instead of HTTP, the backend had to come off SMB onto local disk because of file locking weirdness, the external gateway URL had to be advertised correctly to the WebUI, and the Sharrr IAM credentials had to be resolved directly from Bitwarden when the indirect path didn't work. Each fix was small. Collectively they were the kind of grind that doesn't show up in a feature list.
+The pilot itself was not smooth: CORS had to be set explicitly for the WebGUI, the healthcheck had to be TCP instead of HTTP, the backend had to come off SMB onto local disk because of file locking weirdness, the external gateway URL had to be advertised correctly to the WebUI, and the Sharrr IAM credentials had to be resolved directly from Bitwarden when the indirect path didn't work. Each fix was small. Collectively they were the kind of grind that doesn't show up in a feature list.
 
 None of these are huge headline features. They're the kind of small, steady improvements that I never used to make because the cost of touching anything was too high. With everything in code, the cost is now low enough that I just do them. That doesn't mean any individual change is easy. It means the friction is in the actual problem, not in the act of making the change.
 
@@ -201,8 +201,8 @@ The next stretch is more about polish than new construction. I want to get to th
 
 Beyond that, I'd like to extend the GitOps approach to the corners of my setup I haven't touched yet:
 
-- **pfSense** — still managed through its web UI.
-- **UniFi controller** — config managed by the controller itself, which is fine until the day it isn't.
+- **pfSense**: still managed through its web UI.
+- **UniFi controller**: config managed by the controller itself, which is fine until the day it isn't.
 
 Both are candidates for the same treatment, though I haven't decided whether the juice is worth the squeeze.
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,15 @@
 import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
+import { Fira_Code } from 'next/font/google';
 import '../styles/globals.scss';
+
+const firaCode = Fira_Code({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-fira-code',
+  weight: ['400', '500'],
+});
 
 // Disable SSR for Navbar to preserve framer-motion animations and avoid hydration mismatch
 const Navbar = dynamic(() => import('../components/layout/navbar/navbar'), {
@@ -36,7 +44,7 @@ function MyApp({ Component, pageProps }) {
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta name="theme-color" content={theme === 'dark' ? '#121212' : '#ffffff'} />
       </Head>
-      <div className="app" data-theme={theme}>
+      <div className={`app ${firaCode.variable}`} data-theme={theme}>
         <Navbar theme={theme} newTheme={setTheme} />
         <Component {...pageProps} currentTheme={theme} />
       </div>

--- a/styles/colors.scss
+++ b/styles/colors.scss
@@ -24,6 +24,26 @@
   --modal-border: #555; // Modal border color
   --project-button: #2c3e50; // Project button color
   --valid-cert: #388E3C;
+
+  // Inline code styling
+  --inline-code-bg: #ecedf2;
+  --inline-code-color: #c4146b; // Muted accent for readability on light bg
+  --inline-code-border: #d4d8e0;
+
+  // Code block theme
+  --code-block-bg: #eef0f5;
+  --code-block-border: #d0d7e3;
+  --code-block-header-bg: #e2e5ec;
+  --code-block-text: #2c3e50;
+  --code-block-comment: #8a8a8a;
+  --code-block-keyword: #FF0084;
+  --code-block-number: #EF5350;
+  --code-block-string: #0a7d4a;
+  --code-block-line-number: #a0a0a0;
+  --code-block-meta: #607d8b;
+
+  // Animation
+  --transition-speed: 0.25s;
 }
 
 
@@ -52,4 +72,21 @@
   --link-hover: #cdd9e5; // Link hover color
   --project-button: #cdd9e5; // Project button color
   --valid-cert: #a3e600; // Valid cert color
+
+  // Inline code styling - matches syntax highlighter palette
+  --inline-code-bg: #2d3147;
+  --inline-code-color: #ff5d5d; // Coral red (matches --accent)
+  --inline-code-border: #3a3f5a;
+
+  // Code block theme
+  --code-block-bg: #222538;
+  --code-block-border: #3a3f5a;
+  --code-block-header-bg: #2a2d44;
+  --code-block-text: #cdd9e5;
+  --code-block-comment: #7a9aa9;
+  --code-block-keyword: #a3e600;
+  --code-block-number: #ff5d5d;
+  --code-block-string: #e8c468;
+  --code-block-line-number: #6a8a99;
+  --code-block-meta: #8a9aa6;
 }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,7 +1,7 @@
-@import './colors';
-@import './buttons';
-@import './utils';
-@import './ui';
+@use './colors';
+@use './buttons';
+@use './utils';
+@use './ui';
 
 // Reset default padding and margin for html and body
 html,
@@ -24,7 +24,7 @@ body {
 // Set specific font-family for code blocks
 pre {
   span {
-    font-family: 'Fira Code', monospace;
+    font-family: var(--font-fira-code), Menlo, monospace;
   }
 }
 


### PR DESCRIPTION
## Summary
Theme cohesion pass on the blog renderer. Removes hard-coded colors, fixes a few latent bugs (undefined CSS var, never-loaded font, Sass deprecation), and improves code-block readability/accessibility.

## Changes
**Theme tokens (`styles/colors.scss`)**
- Added `--inline-code-{bg,color,border}` for both themes
- Added `--code-block-{bg,border,header-bg,text,comment,keyword,number,string,line-number,meta}` for both themes
- Added `--transition-speed: 0.25s` (was referenced in ~10 transitions but never defined, so transitions were instant)

**Blog content (`components/blog/blogContent.{js,module.scss}`)**
- Replaced gray-pill `strong` with clean bold using `--navbar-primary`
- Tokenized inline-code styling; uses Fira Code, wraps via `overflow-wrap: anywhere`
- Collapsed `syntaxTheme` + `lightSyntaxTheme` into a single CSS-var-driven theme; removed all hex literals from the JS theme objects
- Code block now has `border-radius: 8px`, a 1px border using `--code-block-border`, and horizontal padding so text isn't flush with the edge
- Added a distinct string color (amber dark / forest green light) since strings previously shared the default text color
- Copy button: floating top-right, revealed on `:hover`/`:focus-within`, always visible on touch via `@media (hover: none)`; toggles `aria-label` between idle and "copied" states with `aria-live="polite"`; SVGs marked `aria-hidden`
- Removed dead `code`/`pre` rules in `.blogDetail` (block code routes through SyntaxHighlighter)

**Font loading (`pages/_app.js`, `styles/globals.scss`)**
- Loaded Fira Code via `next/font/google` (weights 400/500, `display: swap`); exposed as `--font-fira-code` and applied to the root `.app` element. Inline code, block code, and `pre span` now all reference `var(--font-fira-code)`. Previously the font was named in CSS but never loaded, so it silently fell back to the OS monospace.

**Sass migration**
- `@import` is deprecated and slated for removal in Dart Sass 3.0. Migrated `styles/globals.scss` and the nine `*.module.scss` files in `components/` to `@use ... as *;` (the unscoped form preserves access to `$transition-speed` from `ui.scss`).

## Rationale
The previous styling had several issues compounding into a messy look: bold text rendered as gray-on-black "buttons", inline code used a high-saturation accent on a near-invisible background, syntax-highlighted strings shared the default text color, and code blocks bled into the page background with no border or padding. Centralizing theme decisions in CSS variables also makes future theme tweaks single-line changes rather than searching through component files.

## Testing
✅ `npx next build` — passes cleanly on all routes
✅ Verified in dark and light themes via dev server: inline code, code blocks, copy button hover/focus, mobile touch fallback
✅ Sass deprecation warning gone from build output

## Related
None — incremental polish, no issue tracker entry.